### PR TITLE
Support OSX absolute paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ class ExportNodeModules {
 
             const packageName = contextArray.slice(packageNameStart, packageNameEnd);
 
-            const packageJsonFile = path.join(...nodeModulesArray, ...packageName, "package.json");
+            const packageJsonFile = path.join(nodeModulesArray.join(path.sep), ...packageName, "package.json");
             let packageJson;
             try {
               packageJson = JSON.parse(fs.readFileSync(packageJsonFile, "UTF-8"));


### PR DESCRIPTION
Hey there, I came across your fork as I had upgraded to Webpack 4 and the original repo no longer supported that. I did noticed that this works on Windows, but fails on Mac. It's due to the fact that the absolute paths on Mac start with a `/`, and as its the path seperator the array nodeModulesArray correctly has a `''` as its first index. But when using the spread operator, it will filter that out, so your path start with something like `User/...` rather than `/User/...`, and the plugin fails to find files. If you just join array back to a string before passing to path.join, then the problem resolves itself.